### PR TITLE
Add additional special keys

### DIFF
--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -17,7 +17,7 @@
                 &kp TAB   &kp Q     &kp W     &kp E     &kp R     &kp T     &kp Y     &kp U     &kp I     &kp O     &kp P
                   &kp LCTRL &kp A     &kp S     &kp D     &kp F     &kp G     &kp H     &kp J     &kp K     &kp L     &kp RET
                     &kp LSHFT &kp Z    &kp X    &kp C    &kp V    &kp B    &kp N    &kp M    &kp DOT  &kp RSHFT
-                &kp LCTRL &mo LOWER &kp LALT  &kp LGUI  &mo RAISE     &kp SPACE     &kp LEFT    &kp DOWN    &kp UP    &kp RIGHT
+                &kp LCTRL   &mo LOWER   &mo RAISE   &kp LALT    &kp LGUI    &kp SPACE   &kp LEFT    &kp DOWN    &kp UP      &kp RIGHT
             >;
 
         };
@@ -42,7 +42,7 @@
                   &kp GRAVE    &none     &none    &none    &none    &none    &none    &none    &kp MINUS    &kp EQUAL    &none
                 &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
                   &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
-                    &none    &none     &none    &none    &none    &none    &none    &none    &none    &none
+                    &none    &none     &none    &none    &none    &none    &none    &none    &kp KP_COMMA    &none
                 &none    &none     &none    &none    &none    &none    &none    &none    &none    &none
             >;
 

--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -42,7 +42,7 @@
                   &kp GRAVE    &none     &none    &none    &none    &none    &none    &none    &kp MINUS    &kp EQUAL    &none
                 &none    &none     &none    &none    &none    &none    &none    &none    &kp LBKT    &kp RBKT    &kp BSLH
                   &none    &none     &none    &none    &none    &none    &none    &none    &kp SEMI    &kp APOS    &none
-                    &none    &none     &none    &none    &none    &none    &none    &none    &kp KP_COMMA    &none
+                    &none    &none     &none    &none    &none    &none    &kp LT    &kp GT    &kp COMMA    &none
                 &none    &none     &none    &none    &none    &none    &none    &none    &none    &none
             >;
 

--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -20,6 +20,7 @@
         dotqmark: dot_question {
             compatible = "zmk,behavior-mod-morph";
             label = "DOT_QUESTION";
+            #binding-cells = <0>;
             bindings = <&kp DOT>, <&kp QUESTION>;
             mods = <(MOD_LSFT|MOD_RSFT)>;
         };

--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -9,14 +9,6 @@
 
     behaviors {
 
-        gresc: grave_escape {
-            compatible = "zmk,behavior-mod-morph";
-            label = "GRAVE_ESCAPE";
-            #binding-cells = <0>;
-            bindings = <&kp A>, <&kp GRAVE>;
-            mods = <(MOD_LSFT|MOD_RSFT)>;
-        };
-
         dotqmark: dot_question {
             compatible = "zmk,behavior-mod-morph";
             label = "DOT_QUESTION";
@@ -59,12 +51,12 @@
         raise_layer {
 
             bindings = <
-                &gresc    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
+                &none    &none    &none    &none    &none    &none    &none    &none    &none    &none    &none
                   &kp GRAVE    &none     &none    &none    &none    &none    &none    &none    &kp MINUS    &kp EQUAL    &none
-                &none    &none     &none    &none    &none    &none    &none    &none    &kp LBKT    &kp RBKT    &kp BSLH
+                &none    &none    &none    &none    &none    &none    &none    &none    &kp LBKT    &kp RBKT    &kp BSLH
                   &none    &none     &none    &none    &none    &none    &none    &none    &kp SEMI    &kp APOS    &none
                     &kp LSHFT  &none     &none    &none    &none    &none    &kp LT    &kp GT    &kp COMMA    &kp RSHFT
-                &none    &none     &none    &none    &none    &none    &none    &none    &none    &none
+                &kp LCTRL    &none     &none    &kp LALT    &kp LGUI    &none    &none    &none    &none    &none
             >;
 
         };

--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -6,6 +6,18 @@
 #define RAISE 2
 
 / {
+
+{
+    behaviors {
+        gresc: grave_escape {
+            compatible = "zmk,behavior-mod-morph";
+            label = "GRAVE_ESCAPE";
+            #binding-cells = <0>;
+            bindings = <&kp A>, <&kp GRAVE>;
+            mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
+        };
+    };
+
     keymap {
         compatible = "zmk,keymap";
 
@@ -38,7 +50,7 @@
         raise_layer {
 
             bindings = <
-                &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
+                &gresc    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
                   &kp GRAVE    &none     &none    &none    &none    &none    &none    &none    &kp MINUS    &kp EQUAL    &none
                 &none    &none     &none    &none    &none    &none    &none    &none    &kp LBKT    &kp RBKT    &kp BSLH
                   &none    &none     &none    &none    &none    &none    &none    &none    &kp SEMI    &kp APOS    &none

--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -40,7 +40,7 @@
             bindings = <
                 &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
                   &kp GRAVE    &none     &none    &none    &none    &none    &none    &none    &kp MINUS    &kp EQUAL    &none
-                &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
+                &none    &none     &none    &none    &none    &none    &none    &none    &kp LBKT    &kp RBKT    &kp BSLH
                   &none    &none     &none    &none    &none    &none    &none    &none    &kp SEMI    &kp APOS    &none
                     &none    &none     &none    &none    &none    &none    &none    &none    &kp KP_COMMA    &none
                 &none    &none     &none    &none    &none    &none    &none    &none    &none    &none

--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -8,13 +8,22 @@
 / {
 
     behaviors {
+
         gresc: grave_escape {
             compatible = "zmk,behavior-mod-morph";
             label = "GRAVE_ESCAPE";
             #binding-cells = <0>;
             bindings = <&kp A>, <&kp GRAVE>;
-            mods = <(MOD_LGUI|MOD_LSFT|MOD_RGUI|MOD_RSFT)>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
         };
+
+        dotqmark: dot_question {
+            compatible = "zmk,behavior-mod-morph";
+            label = "DOT_QUESTION";
+            bindings = <&kp DOT>, <&kp QUESTION>;
+            mods = <(MOD_LSFT|MOD_RSFT)>;
+        };
+
     };
 
     keymap {
@@ -27,7 +36,7 @@
                   &kp N1    &kp N2    &kp N3    &kp N4    &kp N5    &kp N6    &kp N7    &kp N8    &kp N9    &kp N0    &kp BSPC
                 &kp TAB   &kp Q     &kp W     &kp E     &kp R     &kp T     &kp Y     &kp U     &kp I     &kp O     &kp P
                   &kp LCTRL &kp A     &kp S     &kp D     &kp F     &kp G     &kp H     &kp J     &kp K     &kp L     &kp RET
-                    &kp LSHFT &kp Z    &kp X    &kp C    &kp V    &kp B    &kp N    &kp M    &kp DOT  &kp RSHFT
+                    &kp LSHFT &kp Z    &kp X    &kp C    &kp V    &kp B    &kp N    &kp M    &dotqmark  &kp RSHFT
                 &kp LCTRL   &mo LOWER   &mo RAISE   &kp LALT    &kp LGUI    &kp SPACE   &kp LEFT    &kp DOWN    &kp UP      &kp RIGHT
             >;
 

--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -41,7 +41,7 @@
                 &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
                   &kp GRAVE    &none     &none    &none    &none    &none    &none    &none    &kp MINUS    &kp EQUAL    &none
                 &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
-                  &none    &none     &none    &none    &none    &none    &none    &none    &none    &none    &none
+                  &none    &none     &none    &none    &none    &none    &none    &none    &kp SEMI    &kp APOS    &none
                     &none    &none     &none    &none    &none    &none    &none    &none    &kp KP_COMMA    &none
                 &none    &none     &none    &none    &none    &none    &none    &none    &none    &none
             >;

--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -63,7 +63,7 @@
                   &kp GRAVE    &none     &none    &none    &none    &none    &none    &none    &kp MINUS    &kp EQUAL    &none
                 &none    &none     &none    &none    &none    &none    &none    &none    &kp LBKT    &kp RBKT    &kp BSLH
                   &none    &none     &none    &none    &none    &none    &none    &none    &kp SEMI    &kp APOS    &none
-                    &none    &none     &none    &none    &none    &none    &kp LT    &kp GT    &kp COMMA    &none
+                    &kp LSHFT  &none     &none    &none    &none    &none    &kp LT    &kp GT    &kp COMMA    &kp RSHFT
                 &none    &none     &none    &none    &none    &none    &none    &none    &none    &none
             >;
 

--- a/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
+++ b/keyboard-firmware/boards/shields/little_luggable/little_luggable.keymap
@@ -7,7 +7,6 @@
 
 / {
 
-{
     behaviors {
         gresc: grave_escape {
             compatible = "zmk,behavior-mod-morph";


### PR DESCRIPTION
This change fleshes out the raised layer, adding support for all the standard US-en keys that are omitted on the default layer. It also adjusts the behaviour of the key to the left of right-shift to make it DOT and QUESTION by default.
